### PR TITLE
Restore get_html in Annotatable XBlock

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,13 @@ Change Log
 
 Unreleased
 **********
+0.6.0 – 2025-08-13
+**********************************************
+
+Added
+=====
+
+* Restore get_html in the extracted Annotatable XBlock to match existing edx-platform
 
 0.5.0 – 2025-08-8
 **********************************************

--- a/xblocks_contrib/__init__.py
+++ b/xblocks_contrib/__init__.py
@@ -11,4 +11,4 @@ from .problem import ProblemBlock
 from .video import VideoBlock
 from .word_cloud import WordCloudBlock
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/xblocks_contrib/annotatable/annotatable.py
+++ b/xblocks_contrib/annotatable/annotatable.py
@@ -163,18 +163,22 @@ class AnnotatableBlock(XBlock):
             return etree.tostring(instructions, encoding="unicode")
         return None
 
+    def get_html(self):
+        """Returns the HTML representation of the XBlock for student view."""
+        return {
+            "element_id": uuid.uuid1(0),
+            "display_name": self.display_name,
+            "instructions_html": self._extract_instructions(etree.fromstring(self.data)),
+            "content_html": self._render_content(),
+        }
+
     def student_view(self, context=None):  # pylint: disable=unused-argument
         """Renders the output that a student will see."""
         frag = Fragment()
         frag.add_content(
             resource_loader.render_django_template(
                 "templates/annotatable.html",
-                {
-                    "element_id": uuid.uuid1(0),
-                    "display_name": self.display_name,
-                    "instructions_html": self._extract_instructions(etree.fromstring(self.data)),
-                    "content_html": self._render_content(),
-                },
+                self.get_html(),
                 i18n_service=self.runtime.service(self, "i18n"),
             )
         )

--- a/xblocks_contrib/annotatable/tests/test_annotatable.py
+++ b/xblocks_contrib/annotatable/tests/test_annotatable.py
@@ -120,6 +120,11 @@ class AnnotatableBlockTestCase(unittest.TestCase):
         actual_num_annotations = el.xpath('count(//span[contains(@class,"annotatable-span")])')
         assert expected_num_annotations == actual_num_annotations, "check number of annotations"
 
+    def test_get_html(self):
+        context = self.annotatable.get_html()
+        for key in ["display_name", "element_id", "content_html", "instructions_html"]:
+            assert key in context
+
     def test_extract_instructions(self):
         xmltree = etree.fromstring(self.sample_xml)
 


### PR DESCRIPTION
Restore get_html in the extracted Annotatable XBlock to match existing edx-platform tests and maintain coverage.

Related to https://github.com/openedx/edx-platform/pull/36246/files/fe946741a1eb1a154518bc52a3c146cf059e60d1#r2266775894