### PR TITLE
feat: add the pointer tag support for the extracted XBlocks

### DIFF
--- a/xblocks_contrib/common/xml_utils.py
+++ b/xblocks_contrib/common/xml_utils.py
@@ -132,7 +132,7 @@ def own_metadata(block: XBlock) -> dict[str, Any]:
     keys, mapped to their serialized values
     """
     result = {}
-    for field in block.fields.values():  # lint-amnesty, pylint: disable=no-member
+    for field in block.fields.values():
         if field.scope == Scope.settings and field.is_set_on(block):
             try:
                 result[field.name] = field.read_json(block)

--- a/xblocks_contrib/html/html.py
+++ b/xblocks_contrib/html/html.py
@@ -143,7 +143,7 @@ def stringify_children(node):
 # This makes our block more resilient. It won't crash in test environments
 # where the user service might not be available.
 @XBlock.wants("user")
-class HtmlBlock(LegacyXmlMixin, XBlock):  # pylint: disable=abstract-method
+class HtmlBlock(LegacyXmlMixin, XBlock):
     """
     The HTML XBlock.
     """
@@ -268,7 +268,7 @@ class HtmlBlock(LegacyXmlMixin, XBlock):  # pylint: disable=abstract-method
         data = data.replace("%%COURSE_ID%%", str(self.scope_ids.usage_id.context_key))
         return data
 
-    def studio_view(self, context=None):  # pylint: disable=unused-argument
+    def studio_view(self, context=None):
         """Return a fragment that contains the html for the studio view."""
         # Only the ReactJS editor is supported for this block.
         # See https://github.com/openedx/frontend-app-authoring/tree/master/src/editors/containers/TextEditor

--- a/xblocks_contrib/lti/lti.py
+++ b/xblocks_contrib/lti/lti.py
@@ -84,9 +84,9 @@ except ModuleNotFoundError:
     from xblockutils.resources import ResourceLoader
     from xblockutils.studio_editable import StudioEditableXBlockMixin
 
-from .lti_2_util import LTI20BlockMixin, LTIError
-
 from xblocks_contrib.common.xml_utils import LegacyXmlMixin
+
+from .lti_2_util import LTI20BlockMixin, LTIError
 
 # The anonymous user ID for the user in the course.
 ATTR_KEY_ANONYMOUS_USER_ID = 'edx-platform.anonymous_user_id'
@@ -1018,12 +1018,12 @@ oauth_consumer_key="", oauth_signature="frVp4JuvT1mVXlxktiAUjQ7%2F1cw%3D"'}
         return close_date is not None and datetime.datetime.now(UTC) > close_date
 
     @classmethod
-    def definition_from_xml(cls, xml_object, system):  # lint-amnesty, pylint: disable=unused-argument
+    def definition_from_xml(cls, xml_object, system):
         if len(xml_object) == 0 and len(list(xml_object.items())) == 0:
             return {'data': ''}, []
         return {'data': etree.tostring(xml_object, pretty_print=True, encoding='unicode')}, []
 
-    def definition_to_xml(self, resource_fs):  # lint-amnesty, pylint: disable=unused-argument
+    def definition_to_xml(self, resource_fs):
         if self.data:
             return etree.fromstring(self.data)
         return etree.Element(self.category)

--- a/xblocks_contrib/poll/poll.py
+++ b/xblocks_contrib/poll/poll.py
@@ -304,20 +304,22 @@ class PollBlock(LegacyXmlMixin, XBlock):
         return result
 
     @classmethod
-    def definition_from_xml(cls, xml_object, system):  # pylint: disable=unused-argument
-        """Pull out the data into dictionary.
+    def definition_from_xml(cls, xml_object, system):
+        """
+        Pull out the data into a dictionary.
 
         Args:
-            xml_object: xml from file.
+            xml_object: XML from file.
             system: `system` object.
 
         Returns:
-            (definition, children) - tuple
-            definition - dict:
-                {
-                    'answers': <List of answers>,
-                    'question': <Question string>
-                }
+            tuple: A tuple ``(definition, children)``.
+
+            definition (dict):
+                A dictionary containing:
+
+                - ``answers`` (list): List of answers.
+                - ``question`` (str): Question string.
         """
         # Check for presense of required tags in xml.
         if len(xml_object.xpath(cls._child_tag_name)) == 0:
@@ -338,7 +340,7 @@ class PollBlock(LegacyXmlMixin, XBlock):
         children = []
         return (definition, children)
 
-    def definition_to_xml(self, resource_fs=None):  # pylint: disable=unused-argument
+    def definition_to_xml(self, resource_fs=None):
         """Return an xml element representing to this definition."""
 
         poll_str = HTML("<{tag_name}>{text}</{tag_name}>").format(tag_name=self._tag_name, text=self.question)

--- a/xblocks_contrib/word_cloud/word_cloud.py
+++ b/xblocks_contrib/word_cloud/word_cloud.py
@@ -313,12 +313,12 @@ class WordCloudBlock(StudioEditableXBlockMixin, LegacyXmlMixin, XBlock):
         return xblock_body
 
     @classmethod
-    def definition_from_xml(cls, xml_object, system):  # lint-amnesty, pylint: disable=unused-argument
+    def definition_from_xml(cls, xml_object, system):
         if len(xml_object) == 0 and len(list(xml_object.items())) == 0:
             return {'data': ''}, []
         return {'data': etree.tostring(xml_object, pretty_print=True, encoding='unicode')}, []
 
-    def definition_to_xml(self, resource_fs):  # lint-amnesty, pylint: disable=unused-argument
+    def definition_to_xml(self, resource_fs):
         if self.data:
             return etree.fromstring(self.data)
         return etree.Element(self.category)


### PR DESCRIPTION
- resolves: https://github.com/openedx/public-engineering/issues/457

This PR adds the pointer tag OLX support for the following extracted XBlocks:

1. WordCloud
2. LTI
3. Annotatable
4. Poll

We are enabling the WordCloud, Annotatable and Poll XBlocks in this edx-platform PR: https://github.com/openedx/edx-platform/pull/37740.