### PR TITLE
docs: Update README with criteria for new blocks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ The possible XBlock statuses are:
 Additional XBlocks that belong here
 ***********************************
 
-Over time, more XBlocks may be moved here. An XBlock belongs here if and only if:
+Over time, more XBlocks may be moved here. An XBlock belongs here if and only if both of the following are true:
 
 1. **It needs to be part of the out-of-the-box Open edX experience, as agreed upon by the
    Product Working Group.** Otherwise, perhaps the block belongs in `xblocks-extra <https://github.com/openedx/xblocks-extra>`_,


### PR DESCRIPTION
@feanil @openedx/axim-aximprovements - Let me know your thoughts.

This would be a a change from how xblocks-contrib started. We'd originally imagined that only the most critical blocks (like ProblemBlock) would go here. But we've started to feel that having three separate repos for blocks might be over-engineering. With this change, we'd only need two repos: xblocks-contrib and xblocks-extra.