### PR TITLE
Pinning setuptool <= 80.9.0 to fix package resource error

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,9 +8,9 @@ appdirs==1.4.4
     # via fs
 asgiref==3.11.1
     # via django
-boto3==1.42.41
+boto3==1.42.45
     # via fs-s3fs
-botocore==1.42.41
+botocore==1.42.45
     # via
     #   boto3
     #   s3transfer

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,3 +10,9 @@
 
 # Common constraints for edx repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+
+# Date: 2026-02-10
+# setuptools >=80.9.0 has breaking tests. More details
+# https://github.com/openedx/openedx-platform/pull/37991
+# we will unpin setuptools once the issue is resolved and the tests are passing.
+setuptools<=80.9.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -19,7 +19,7 @@ asgiref==3.11.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django
-astroid==4.0.3
+astroid==4.0.4
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -29,12 +29,12 @@ binaryornot==0.4.4
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   cookiecutter
-boto3==1.42.41
+boto3==1.42.45
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   fs-s3fs
-botocore==1.42.41
+botocore==1.42.45
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -95,7 +95,7 @@ cookiecutter==2.6.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   xblock-sdk
-coverage[toml]==7.13.3
+coverage[toml]==7.13.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -32,11 +32,11 @@ binaryornot==0.4.4
     # via
     #   -r requirements/test.txt
     #   cookiecutter
-boto3==1.42.41
+boto3==1.42.45
     # via
     #   -r requirements/test.txt
     #   fs-s3fs
-botocore==1.42.41
+botocore==1.42.45
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -51,8 +51,6 @@ certifi==2026.1.4
     # via
     #   -r requirements/test.txt
     #   requests
-cffi==2.0.0
-    # via cryptography
 chardet==5.2.0
     # via
     #   -r requirements/test.txt
@@ -77,12 +75,10 @@ cookiecutter==2.6.0
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
-coverage[toml]==7.13.3
+coverage[toml]==7.13.4
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==46.0.4
-    # via secretstorage
 ddt==1.7.2
     # via -r requirements/test.txt
 distlib==0.4.0
@@ -137,7 +133,7 @@ fs-s3fs==1.1.1
     #   -r requirements/test.txt
     #   openedx-django-pyfs
     #   xblock-sdk
-id==1.5.0
+id==1.6.1
     # via twine
 idna==3.11
     # via
@@ -157,10 +153,6 @@ jaraco-context==6.1.0
     # via keyring
 jaraco-functools==4.4.0
     # via keyring
-jeepney==0.9.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.6
     # via
     #   -r requirements/test.txt
@@ -244,8 +236,6 @@ polib==1.2.0
     # via
     #   -r requirements/test.txt
     #   edx-i18n-tools
-pycparser==3.0
-    # via cffi
 pydata-sphinx-theme==0.15.4
     # via sphinx-book-theme
 pygments==2.19.2
@@ -309,7 +299,6 @@ requests==2.32.5
     # via
     #   -r requirements/test.txt
     #   cookiecutter
-    #   id
     #   requests-toolbelt
     #   sphinx
     #   twine
@@ -331,8 +320,6 @@ s3transfer==0.16.0
     # via
     #   -r requirements/test.txt
     #   boto3
-secretstorage==3.5.0
-    # via keyring
 simplejson==3.20.2
     # via
     #   -r requirements/test.txt
@@ -399,6 +386,7 @@ urllib3==2.6.3
     # via
     #   -r requirements/test.txt
     #   botocore
+    #   id
     #   requests
     #   twine
 virtualenv==20.36.1

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -14,5 +14,7 @@ pip==25.3
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/pip.in
-setuptools==80.10.2
-    # via -r requirements/pip.in
+setuptools==80.9.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -16,7 +16,7 @@ asgiref==3.11.1
     # via
     #   -r requirements/test.txt
     #   django
-astroid==4.0.3
+astroid==4.0.4
     # via
     #   pylint
     #   pylint-celery
@@ -24,11 +24,11 @@ binaryornot==0.4.4
     # via
     #   -r requirements/test.txt
     #   cookiecutter
-boto3==1.42.41
+boto3==1.42.45
     # via
     #   -r requirements/test.txt
     #   fs-s3fs
-botocore==1.42.41
+botocore==1.42.45
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -71,7 +71,7 @@ cookiecutter==2.6.0
     # via
     #   -r requirements/test.txt
     #   xblock-sdk
-coverage[toml]==7.13.3
+coverage[toml]==7.13.4
     # via
     #   -r requirements/test.txt
     #   pytest-cov

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -16,11 +16,11 @@ asgiref==3.11.1
     #   django
 binaryornot==0.4.4
     # via cookiecutter
-boto3==1.42.41
+boto3==1.42.45
     # via
     #   -r requirements/base.txt
     #   fs-s3fs
-botocore==1.42.41
+botocore==1.42.45
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -45,7 +45,7 @@ colorama==0.4.6
     # via tox
 cookiecutter==2.6.0
     # via xblock-sdk
-coverage[toml]==7.13.3
+coverage[toml]==7.13.4
     # via pytest-cov
 ddt==1.7.2
     # via -r requirements/test.in

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ deps =
     django42: Django>=4.2,<5.0
     django52: Django>=5.2,<6.0
     -r{toxinidir}/requirements/test.txt
+    -r{toxinidir}/requirements/pip.txt
 allowlist_externals =
     mkdir
 commands =
@@ -41,6 +42,7 @@ allowlist_externals =
     rm
 deps =
     -r{toxinidir}/requirements/doc.txt
+    -r{toxinidir}/requirements/pip.txt
 commands =
     doc8 --ignore-path docs/_build README.rst docs
     rm -f docs/xblocks_contrib.rst


### PR DESCRIPTION
## Description

setuptools >=80.9.0 has breaking tests. 
More details: https://github.com/openedx/openedx-platform/pull/37991

we will unpin setuptools once the issue is resolved and the tests will start passing.