### PR TITLE
fix: match video download link font size with transcripts

### DIFF
--- a/xblocks_contrib/video/assets/css/video.css
+++ b/xblocks_contrib/video/assets/css/video.css
@@ -98,6 +98,9 @@
 }
 
 .video .wrapper-downloads .wrapper-download-video .video-sources {
+    /* Match it with Transcipts */
+    font-size: 16px !important;
+    font-weight: unset;
     margin: 0;
 }
 


### PR DESCRIPTION
### Related Ticket
https://github.com/mitodl/hq/issues/10469 (MIT Internal)

### Openedx-platform
https://github.com/openedx/openedx-platform/pull/38267

## Description
This pull request makes minor adjustments to the CSS styling for video downloads and transcript options to ensure consistency in font size and weight between the video sources and transcript download links.

- **Styling Consistency Updates**
  * Set the font size of `.video-sources` to `16px` and unset its font weight to match the transcript options.
  * Commented out the explicit font size setting for transcript option buttons to prevent overriding and maintain consistency with `.video-sources`.

## Testing instructions

Visual difference is clearly visible in Safari browsers, best to test it in Safari


## Before
<img width="1235" height="510" alt="image" src="https://github.com/user-attachments/assets/60fda670-df02-4dba-b43d-b7560942d165" />


## After
<img width="1235" height="510" alt="image" src="https://github.com/user-attachments/assets/b2d41b55-e900-466d-a36e-423946a58366" />

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
