### PR TITLE
chore: remove web fragments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,11 +14,20 @@ Change Log
 Unreleased
 **********
 
+0.17.0 - 2026-06-11
+
+Changed
+=======
+
+* Upgrade XBlock dependency and remove web-fragments dependency in favor of
+  XBlock's packaging of this module.
+
 0.16.0 - 2026-04-21
 **********************************************
 
 Fixed
 =====
+
 * Fix video block editor issues while editing in the Content Library
 
 0.16.0 - 2026-04-21

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -26,7 +26,6 @@ random2
 requests
 shapely
 simplejson
-web-fragments
 webob
 wrapt
 xblock

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -31,7 +31,7 @@ click==8.4.1
     #   nltk
 code-annotations==3.0.0
     # via edx-toggles
-cryptography==48.0.0
+cryptography==48.0.1
     # via pyjwt
 defusedxml==0.7.1
     # via -r requirements/base.in
@@ -93,6 +93,7 @@ edx-opaque-keys==4.0.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
+    #   xblock
 edx-submissions==4.0.0
     # via -r requirements/base.in
 edx-toggles==6.0.0
@@ -223,7 +224,7 @@ sympy==1.14.0
     # via openedx-calc
 text-unidecode==1.3
     # via python-slugify
-tqdm==4.68.1
+tqdm==4.68.2
     # via nltk
 typing-extensions==4.15.0
     # via
@@ -231,10 +232,6 @@ typing-extensions==4.15.0
     #   edx-opaque-keys
 urllib3==2.7.0
     # via requests
-web-fragments==4.0.0
-    # via
-    #   -r requirements/base.in
-    #   xblock
 webencodings==0.5.1
     # via html5lib
 webob==1.8.10
@@ -243,7 +240,7 @@ webob==1.8.10
     #   xblock
 wrapt==2.2.1
     # via -r requirements/base.in
-xblock==6.1.0
+xblock==6.2.0
     # via -r requirements/base.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -89,7 +89,7 @@ coverage[toml]==7.14.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==48.0.0
+cryptography==48.0.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -106,7 +106,7 @@ dill==0.4.1
     # via
     #   -r requirements/quality.txt
     #   pylint
-distlib==0.4.1
+distlib==0.4.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -198,6 +198,7 @@ edx-opaque-keys==4.0.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
+    #   xblock
 edx-submissions==4.0.0
     # via
     #   -r requirements/quality.txt
@@ -211,7 +212,7 @@ edxval==4.0.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-filelock==3.29.1
+filelock==3.29.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -442,7 +443,7 @@ python-dateutil==2.9.0.post0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   xblock
-python-discovery==1.4.0
+python-discovery==1.4.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -554,7 +555,7 @@ tox==4.55.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-tqdm==4.68.1
+tqdm==4.68.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -570,16 +571,11 @@ urllib3==2.7.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   requests
-virtualenv==21.4.2
+virtualenv==21.4.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   tox
-web-fragments==4.0.0
-    # via
-    #   -r requirements/quality.txt
-    #   -r requirements/test.txt
-    #   xblock
 webencodings==0.5.1
     # via
     #   -r requirements/quality.txt
@@ -598,7 +594,7 @@ wrapt==2.2.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-xblock==6.1.0
+xblock==6.2.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -66,7 +66,7 @@ coverage[toml]==7.14.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==48.0.0
+cryptography==48.0.1
     # via
     #   -r requirements/test.txt
     #   pyjwt
@@ -74,7 +74,7 @@ ddt==1.7.2
     # via -r requirements/test.txt
 defusedxml==0.7.1
     # via -r requirements/test.txt
-distlib==0.4.1
+distlib==0.4.2
     # via
     #   -r requirements/test.txt
     #   virtualenv
@@ -157,6 +157,7 @@ edx-opaque-keys==4.0.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
+    #   xblock
 edx-submissions==4.0.0
     # via -r requirements/test.txt
 edx-toggles==6.0.0
@@ -165,7 +166,7 @@ edx-toggles==6.0.0
     #   edxval
 edxval==4.0.1
     # via -r requirements/test.txt
-filelock==3.29.1
+filelock==3.29.3
     # via
     #   -r requirements/test.txt
     #   python-discovery
@@ -321,7 +322,7 @@ python-dateutil==2.9.0.post0
     # via
     #   -r requirements/test.txt
     #   xblock
-python-discovery==1.4.0
+python-discovery==1.4.2
     # via
     #   -r requirements/test.txt
     #   tox
@@ -428,7 +429,7 @@ tomli-w==1.2.0
     #   tox
 tox==4.55.1
     # via -r requirements/test.txt
-tqdm==4.68.1
+tqdm==4.68.2
     # via
     #   -r requirements/test.txt
     #   nltk
@@ -442,14 +443,10 @@ urllib3==2.7.0
     # via
     #   -r requirements/test.txt
     #   requests
-virtualenv==21.4.2
+virtualenv==21.4.3
     # via
     #   -r requirements/test.txt
     #   tox
-web-fragments==4.0.0
-    # via
-    #   -r requirements/test.txt
-    #   xblock
 webencodings==0.5.1
     # via
     #   -r requirements/test.txt
@@ -460,7 +457,7 @@ webob==1.8.10
     #   xblock
 wrapt==2.2.1
     # via -r requirements/test.txt
-xblock==6.1.0
+xblock==6.2.0
     # via -r requirements/test.txt
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -65,7 +65,7 @@ coverage[toml]==7.14.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==48.0.0
+cryptography==48.0.1
     # via
     #   -r requirements/test.txt
     #   pyjwt
@@ -75,7 +75,7 @@ defusedxml==0.7.1
     # via -r requirements/test.txt
 dill==0.4.1
     # via pylint
-distlib==0.4.1
+distlib==0.4.2
     # via
     #   -r requirements/test.txt
     #   virtualenv
@@ -152,6 +152,7 @@ edx-opaque-keys==4.0.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
+    #   xblock
 edx-submissions==4.0.0
     # via -r requirements/test.txt
 edx-toggles==6.0.0
@@ -160,7 +161,7 @@ edx-toggles==6.0.0
     #   edxval
 edxval==4.0.1
     # via -r requirements/test.txt
-filelock==3.29.1
+filelock==3.29.3
     # via
     #   -r requirements/test.txt
     #   python-discovery
@@ -331,7 +332,7 @@ python-dateutil==2.9.0.post0
     # via
     #   -r requirements/test.txt
     #   xblock
-python-discovery==1.4.0
+python-discovery==1.4.2
     # via
     #   -r requirements/test.txt
     #   tox
@@ -418,7 +419,7 @@ tomlkit==0.15.0
     #   pylint
 tox==4.55.1
     # via -r requirements/test.txt
-tqdm==4.68.1
+tqdm==4.68.2
     # via
     #   -r requirements/test.txt
     #   nltk
@@ -431,14 +432,10 @@ urllib3==2.7.0
     # via
     #   -r requirements/test.txt
     #   requests
-virtualenv==21.4.2
+virtualenv==21.4.3
     # via
     #   -r requirements/test.txt
     #   tox
-web-fragments==4.0.0
-    # via
-    #   -r requirements/test.txt
-    #   xblock
 webencodings==0.5.1
     # via
     #   -r requirements/test.txt
@@ -449,7 +446,7 @@ webob==1.8.10
     #   xblock
 wrapt==2.2.1
     # via -r requirements/test.txt
-xblock==6.1.0
+xblock==6.2.0
     # via -r requirements/test.txt
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -52,7 +52,7 @@ colorama==0.4.6
     # via tox
 coverage[toml]==7.14.1
     # via pytest-cov
-cryptography==48.0.0
+cryptography==48.0.1
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -60,7 +60,7 @@ ddt==1.7.2
     # via -r requirements/test.in
 defusedxml==0.7.1
     # via -r requirements/base.txt
-distlib==0.4.1
+distlib==0.4.2
     # via virtualenv
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
@@ -132,6 +132,7 @@ edx-opaque-keys==4.0.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
+    #   xblock
 edx-submissions==4.0.0
     # via -r requirements/base.txt
 edx-toggles==6.0.0
@@ -140,7 +141,7 @@ edx-toggles==6.0.0
     #   edxval
 edxval==4.0.1
     # via -r requirements/base.txt
-filelock==3.29.1
+filelock==3.29.3
     # via
     #   python-discovery
     #   tox
@@ -276,7 +277,7 @@ python-dateutil==2.9.0.post0
     # via
     #   -r requirements/base.txt
     #   xblock
-python-discovery==1.4.0
+python-discovery==1.4.2
     # via
     #   tox
     #   virtualenv
@@ -354,7 +355,7 @@ tomli-w==1.2.0
     # via tox
 tox==4.55.1
     # via -r requirements/test.in
-tqdm==4.68.1
+tqdm==4.68.2
     # via
     #   -r requirements/base.txt
     #   nltk
@@ -367,12 +368,8 @@ urllib3==2.7.0
     # via
     #   -r requirements/base.txt
     #   requests
-virtualenv==21.4.2
+virtualenv==21.4.3
     # via tox
-web-fragments==4.0.0
-    # via
-    #   -r requirements/base.txt
-    #   xblock
 webencodings==0.5.1
     # via
     #   -r requirements/base.txt
@@ -383,7 +380,7 @@ webob==1.8.10
     #   xblock
 wrapt==2.2.1
     # via -r requirements/base.txt
-xblock==6.1.0
+xblock==6.2.0
     # via -r requirements/base.txt
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/xblocks_contrib/__init__.py
+++ b/xblocks_contrib/__init__.py
@@ -9,4 +9,4 @@ from .problem import ProblemBlock
 from .video import VideoBlock
 from .word_cloud import WordCloudBlock
 
-__version__ = "0.16.1"
+__version__ = "0.17.0"


### PR DESCRIPTION
This PR removes web-fragments as an independent package, now that it's included in XBlock's packaging directly.

See [this PR](https://github.com/openedx/XBlock/pull/917#issuecomment-4684554574).

CI testing should work well enough to validate, but you can test by mounting this repo in Tutor, installing it, and then using some of the blocks to verify they can still load their contents.

Ticket: https://github.com/openedx/web-fragments/issues/309

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [x] Unit tests added/updated
- [x] Manual testing instructions provided
- [x] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
