### PR TITLE
fix: support AnnotatableBlock in the new content runtime

### DIFF
--- a/xblocks_contrib/annotatable/annotatable.py
+++ b/xblocks_contrib/annotatable/annotatable.py
@@ -247,6 +247,28 @@ class AnnotatableBlock(LegacyXmlMixin, XBlock):
         ]
 
     @classmethod
+    def parse_xml_new_runtime(cls, node, runtime, keys):
+        """
+        Interpret the parsed XML in `node`, creating a new instance of this
+        module.
+        """
+        # In the new/openedx_content-based runtime, XModule parsing (from
+        # XmlMixin) is disabled, so definition_from_xml will not be
+        # called, and instead the "normal" XBlock parse_xml will be used.
+        # However, it's not compatible with RawMixin, so we implement
+        # support here.
+        data_field_value = cls.definition_from_xml(node, None)[0]["data"]
+        for child in node.getchildren():
+            node.remove(child)
+        # Get attributes, if any, via normal parse_xml.
+        try:
+            block = super().parse_xml_new_runtime(node, runtime, keys)
+        except AttributeError:
+            block = super().parse_xml(node, runtime, keys)
+        block.data = data_field_value
+        return block
+
+    @classmethod
     def definition_from_xml(cls, xml_object, system):
         if len(xml_object) == 0 and len(list(xml_object.items())) == 0:
             return {'data': ''}, []


### PR DESCRIPTION
Closes: https://github.com/openedx/openedx-platform/issues/38809

## What

Add a `parse_xml_new_runtime` override to `AnnotatableBlock` so the block can be loaded by the new openedx_content-based content runtime (Content Libraries).

## Why

While extracting the Annotatable block from `openedx-platform`, we parted ways with `RawMixin`, which contains the `parse_xml_new_runtime` method. That method is still required by the extracted block to be compatible with the new content runtime, and it was missed during extraction.

Without it, opening an annotatable block in a Content Library crashes with:

```
NotImplementedError: XML Serialization is only supported with OpenedXContentRuntime
```

The new runtime loads blocks via `parse_xml_new_runtime`. Annotatable only inherited the [LegacyXmlMixin fallback](https://github.com/openedx/xblocks-core/blob/496bf2d72ffb286a44d134542e9c7eb6cc683fff/xblocks_contrib/legacy_utils/xml_utils.py#L455-L463), which delegates to the [base XBlock.parse_xml](https://github.com/openedx/XBlock/blob/d33a8b191cf80c3f78bd2f24d45acac7cd050b05/xblock/core.py#L763). That base parser [treats every child XML node as a child block](https://github.com/openedx/XBlock/blob/d33a8b191cf80c3f78bd2f24d45acac7cd050b05/xblock/core.py#L789) and calls [runtime.add_node_as_child()](https://github.com/openedx/XBlock/blob/d33a8b191cf80c3f78bd2f24d45acac7cd050b05/xblock/runtime.py#L764), which the new runtime does not support (it raises the error above). Since [annotatable OLX always contains nested markup](https://github.com/openedx/xblocks-core/blob/496bf2d72ffb286a44d134542e9c7eb6cc683fff/xblocks_contrib/annotatable/annotatable.py#L53) (`<instructions>`, `<p>`, `<annotation>`), loading always failed.

## Fix

Copy the [parse_xml_new_runtime](https://github.com/openedx/edx-platform/blob/f999886a1074e8fa8c7467f136ea6fdb27efecf8/xmodule/raw_block.py#L64) method from `RawMixin` into `AnnotatableBlock`. It captures the full inner XML into the `data` field and strips the child nodes before delegating to the base parser. 

## Case study: Problem block (same pattern, already done)

This is exactly how the extracted **Problem block** was handled:

- The **built-in** `ProblemBlock` (in `openedx-platform`) [extends RawMixin](https://github.com/openedx/edx-platform/blob/f999886a1074e8fa8c7467f136ea6fdb27efecf8/xmodule/capa_block.py#L148-L150), [inheriting parse_xml_new_runtime](https://github.com/openedx/edx-platform/blob/f999886a1074e8fa8c7467f136ea6fdb27efecf8/xmodule/raw_block.py#L64).
- The **extracted** `ProblemBlock` (here) [does **not** extend RawMixin](https://github.com/openedx/xblocks-core/blob/876e619f8985fbb0bf72e92298e341d7cadf4b73/xblocks_contrib/problem/capa_block.py#L205), and instead explicitly copies [parse_xml_new_runtime](https://github.com/openedx/xblocks-core/blob/876e619f8985fbb0bf72e92298e341d7cadf4b73/xblocks_contrib/problem/capa_block.py#L2456) into its own class.

The same was done for the `html` and `video` blocks. Annotatable was the one raw-data block where this copy was omitted during extraction; this PR brings it in line.

## Manual testing

1. Create an Annotatable Block in the Course
2. Copy the Block from the Course and paste into Library as Component. Or Import the course components into the Library.
3. Before this change: 500 error (`NotImplementedError` in studio logs). After: the component renders.

### Screenshot 

**Annotatable Block successfully loaded into the Content Library**


<img width="2704" height="3124" alt="screencapture-apps-local-openedx-io-2001-authoring-library-lib-axim-3-components-lb-axim-3-annotatable-annotation-eb2f56-2026-06-26-21_03_52" src="https://github.com/user-attachments/assets/4598df86-2616-4ad2-8729-fe12a44471f9" />
