### PR TITLE
fix: fix the problem score when added in graded sub-section

### DIFF
--- a/xblocks_contrib/problem/capa_block.py
+++ b/xblocks_contrib/problem/capa_block.py
@@ -997,7 +997,10 @@ class ProblemBlock(ScorableXBlockMixin, LegacyXmlMixin, XBlock):
             # real grade history to protect. Reflect the problem's current
             # definition instead of a stale persisted score (e.g. left over from
             # before an author edited the problem after it was first previewed).
-            raw_possible = self.max_score() or raw_possible
+            if "lcp" in self.__dict__:
+                raw_possible = self.lcp.get_max_score()
+            else:
+                raw_possible = self.max_score()
 
         if raw_possible > 0:
             if self.weight is not None:

--- a/xblocks_contrib/problem/capa_block.py
+++ b/xblocks_contrib/problem/capa_block.py
@@ -992,6 +992,13 @@ class ProblemBlock(ScorableXBlockMixin, LegacyXmlMixin, XBlock):
         else:
             raw_earned = raw_possible = 0
 
+        if not self.attempts:
+            # Nothing has ever been submitted for this user/block, so there's no
+            # real grade history to protect. Reflect the problem's current
+            # definition instead of a stale persisted score (e.g. left over from
+            # before an author edited the problem after it was first previewed).
+            raw_possible = self.max_score() or raw_possible
+
         if raw_possible > 0:
             if self.weight is not None:
                 # Progress objects expect total > 0

--- a/xblocks_contrib/problem/capa_block.py
+++ b/xblocks_contrib/problem/capa_block.py
@@ -997,10 +997,7 @@ class ProblemBlock(ScorableXBlockMixin, LegacyXmlMixin, XBlock):
             # real grade history to protect. Reflect the problem's current
             # definition instead of a stale persisted score (e.g. left over from
             # before an author edited the problem after it was first previewed).
-            if "lcp" in self.__dict__:
-                raw_possible = self.lcp.get_max_score()
-            else:
-                raw_possible = self.max_score()
+            raw_possible = self.lcp.get_max_score()
 
         if raw_possible > 0:
             if self.weight is not None:

--- a/xblocks_contrib/problem/tests/test_capa_block.py
+++ b/xblocks_contrib/problem/tests/test_capa_block.py
@@ -2742,6 +2742,94 @@ class ProblemBlockTest(unittest.TestCase):
         other_block.get_progress()
         mock_progress.assert_called_with(1, 1)
 
+    @patch("xblocks_contrib.problem.capa_block.Progress")
+    def test_get_progress_ignores_stale_score_when_unattempted(self, mock_progress):
+        """
+        If a problem has never been attempted, get_progress() should reflect the
+        problem's current max_score() rather than a stale persisted score -- e.g.
+        one left over from a preview/bind that happened before the problem's
+        content was edited to add a real scorable response.
+        """
+        mock_progress.return_value = True
+        block = CapaFactory.create(attempts=0)
+        block.weight = 1
+        # Simulate a stale persisted score, as if this block had been bound/previewed
+        # before its current content (with a scorable response worth 1 point) existed.
+        block.score = Score(raw_earned=0, raw_possible=0)
+
+        block.get_progress()
+
+        mock_progress.assert_called_with(0, 1)
+
+    @patch("xblocks_contrib.problem.capa_block.Progress")
+    def test_get_progress_keeps_historical_score_when_attempted(self, mock_progress):
+        """
+        Once a problem has been attempted, get_progress() must not silently swap in
+        the current max_score() -- the historical score/denominator the learner was
+        actually graded against must be preserved, even if the problem's content or
+        weight has since changed.
+        """
+        mock_progress.return_value = True
+        block = CapaFactory.create(attempts=1)
+        block.weight = None
+        # Historical score computed against an older version of the problem (e.g.
+        # before the author edited it, changing its current max_score() to 1).
+        block.score = Score(raw_earned=1, raw_possible=2)
+
+        block.get_progress()
+
+        mock_progress.assert_called_with(1, 2)
+
+    def test_get_progress_reuses_already_built_lcp(self):
+        """
+        get_progress() should reuse self.lcp when it's already been built (e.g.
+        by handle_ajax, which explicitly touches self.lcp before calling here)
+        instead of re-parsing the problem via max_score(), when the problem
+        hasn't been attempted yet.
+        """
+        block = CapaFactory.create(attempts=0)
+        block.weight = None
+        assert "lcp" in block.__dict__  # CapaFactory.create() forces lcp to build
+
+        # If max_score() were called it would re-parse the problem and return a
+        # value consistent with the current XML (1) -- give it an obviously wrong
+        # value instead so we can tell whether it was actually invoked.
+        block.max_score = Mock(return_value=999)
+
+        _, total = block.get_display_progress()
+
+        block.max_score.assert_not_called()
+        assert total == 1
+
+    def test_get_progress_falls_back_to_max_score_when_lcp_not_built(self):
+        """
+        get_progress() should fall back to max_score() (rather than force a full
+        lcp build) when self.lcp genuinely hasn't been constructed yet.
+        """
+        block = CapaFactory.create(attempts=0)
+        block.weight = None
+        del block.__dict__["lcp"]  # simulate a block whose lcp was never built
+        block.max_score = Mock(return_value=3)
+
+        _, total = block.get_display_progress()
+
+        block.max_score.assert_called_once()
+        assert total == 3
+
+    def test_get_progress_shows_genuine_zero_not_stale_value(self):
+        """
+        A never-attempted problem with no scorable response should show 0 points
+        possible, even if a stale non-zero score was previously persisted -- 0
+        because the problem is genuinely worth 0 points must not be treated the
+        same as "0 because max_score() couldn't be computed", which would wrongly
+        fall back to the old value.
+        """
+        block = CapaFactory.create(xml="<problem/>", attempts=0)
+        block.weight = None
+        block.score = Score(raw_earned=0, raw_possible=5)
+
+        assert block.get_progress() is None
+
     @ddt.data(
         ("never", True, None),
         ("never", False, None),

--- a/xblocks_contrib/problem/tests/test_capa_block.py
+++ b/xblocks_contrib/problem/tests/test_capa_block.py
@@ -2780,16 +2780,15 @@ class ProblemBlockTest(unittest.TestCase):
 
         mock_progress.assert_called_with(1, 2)
 
-    def test_get_progress_reuses_already_built_lcp(self):
+    def test_get_progress_uses_lcp_get_max_score_when_unattempted(self):
         """
-        get_progress() should reuse self.lcp when it's already been built (e.g.
-        by handle_ajax, which explicitly touches self.lcp before calling here)
-        instead of re-parsing the problem via max_score(), when the problem
-        hasn't been attempted yet.
+        get_progress() should use self.lcp.get_max_score() -- not the separate
+        max_score() helper, which would re-parse the problem from scratch --
+        to reflect the problem's current point value when it hasn't been
+        attempted yet.
         """
         block = CapaFactory.create(attempts=0)
         block.weight = None
-        assert "lcp" in block.__dict__  # CapaFactory.create() forces lcp to build
 
         # If max_score() were called it would re-parse the problem and return a
         # value consistent with the current XML (1) -- give it an obviously wrong
@@ -2800,21 +2799,6 @@ class ProblemBlockTest(unittest.TestCase):
 
         block.max_score.assert_not_called()
         assert total == 1
-
-    def test_get_progress_falls_back_to_max_score_when_lcp_not_built(self):
-        """
-        get_progress() should fall back to max_score() (rather than force a full
-        lcp build) when self.lcp genuinely hasn't been constructed yet.
-        """
-        block = CapaFactory.create(attempts=0)
-        block.weight = None
-        del block.__dict__["lcp"]  # simulate a block whose lcp was never built
-        block.max_score = Mock(return_value=3)
-
-        _, total = block.get_display_progress()
-
-        block.max_score.assert_called_once()
-        assert total == 3
 
     def test_get_progress_shows_genuine_zero_not_stale_value(self):
         """


### PR DESCRIPTION
### Related Ticket
https://github.com/mitodl/hq/issues/12023 (MIT internal)

### Description
This pull request makes a targeted improvement to the grading logic in the `CapaBlock` XBlock. The main change ensures that when a learner has not made any attempts on a problem, the possible score reflects the current definition of the problem, rather than a potentially outdated persisted score. This helps maintain grading accuracy, especially after problem edits.

Grading logic improvements:

* Updated `get_progress` in `capa_block.py` to set `raw_possible` to the current `max_score()` when there are no attempts, ensuring the possible score is always up-to-date with the latest problem definition.

### Steps to reproduce: (main branch)
1. Log in as a course author.
2. Go to a unit inside of a graded subsection
3. Add a problem (any problem) - put in something for the problem question and answer.
4. The default for any new problem is to be weighted at 1 point.
5. Save the problem, publish the unit.
6. The problem will show as worth 0 points and ungraded. (see first screenshot)

### Testing
Repeat the above steps after checking out to this branch

**Merge checklist:**
Check off if complete *or* not applicable:
- [x] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [x] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
