### PR TITLE
test: fix flaky video block JS tests

### DIFF
--- a/xblocks_contrib/video/tests/js/html5_video_spec.js
+++ b/xblocks_contrib/video/tests/js/html5_video_spec.js
@@ -123,7 +123,7 @@
 
                         jasmine.waitUntil(function() {
                             return state.videoPlayer.player.getPlayerState() !== STATUS.UNSTARTED;
-                        }).done(done);
+                        }).always(done);
 
                         state.videoPlayer.player.pauseVideo();
                     });
@@ -173,7 +173,7 @@
                         state.videoPlayer.player.playVideo();
                         jasmine.waitUntil(function() {
                             return state.videoPlayer.player.getPlayerState() !== STATUS.UNSTARTED;
-                        }).done(done);
+                        }).always(done);
                     });
 
                     it('player state was changed', function() {
@@ -210,7 +210,7 @@
                         }).then(function() {
                             state.videoPlayer.player.seekTo(2);
                             expect(state.videoPlayer.player.getCurrentTime()).toBe(2);
-                        }).done(done);
+                        }).always(done);
                     });
 
                     it('set new incorrect values', function() {
@@ -249,7 +249,7 @@
                         state.videoPlayer.player.video.currentTime = 3;
                         expect(state.videoPlayer.player.getCurrentTime())
                             .toBe(state.videoPlayer.player.video.currentTime);
-                    }).done(done);
+                    }).always(done);
                 });
 
                 it('playVideo', function() {
@@ -319,7 +319,7 @@
                         var logs = state.videoPlayer.player._getLogs();
                         expect(logs).toEqual(jasmine.any(Array));
                         expect(logs.length).toBeGreaterThan(0);
-                    }).done(done);
+                    }).always(done);
                 });
             });
 

--- a/xblocks_contrib/video/tests/js/video_bumper_spec.js
+++ b/xblocks_contrib/video/tests/js/video_bumper_spec.js
@@ -8,7 +8,7 @@
         waitForPlaying = function(state, done) {
             jasmine.waitUntil(function() {
                 return state.el.hasClass('is-playing');
-            }).done(done);
+            }).always(done);
         };
 
         beforeEach(function() {

--- a/xblocks_contrib/video/tests/js/video_caption_spec.js
+++ b/xblocks_contrib/video/tests/js/video_caption_spec.js
@@ -150,6 +150,8 @@
                 });
 
                 it('fetch the transcript in Flash mode', function(done) {
+                    var transcriptURL = '/transcript/translation/en',
+                        transcriptCall;
                     state = jasmine.initializePlayerYouTube();
                     spyOn(state, 'isFlashMode').and.returnValue(true);
                     state.videoCaption.fetchCaption();
@@ -158,16 +160,18 @@
                         return state.videoCaption.loaded;
                     }).then(function() {
                         expect($.ajaxWithPrefix).toHaveBeenCalledWith({
-                            url: '/transcript/translation/en',
+                            url: transcriptURL,
                             notifyOnError: false,
                             data: jasmine.any(Object),
                             success: jasmine.any(Function),
                             error: jasmine.any(Function)
                         });
-                        expect($.ajaxWithPrefix.calls.mostRecent().args[0].data)
-                            .toEqual({
-                                videoId: 'cogebirgzzM'
-                            });
+                        transcriptCall = $.ajaxWithPrefix.calls.all().find(function(call) {
+                            return call.args[0].url === transcriptURL;
+                        });
+                        expect(transcriptCall.args[0].data).toEqual({
+                            videoId: 'cogebirgzzM'
+                        });
                     }).always(done);
                 });
 

--- a/xblocks_contrib/video/tests/js/video_poster_spec.js
+++ b/xblocks_contrib/video/tests/js/video_poster_spec.js
@@ -32,7 +32,7 @@
             $('.btn-play').click();
             jasmine.waitUntil(function() {
                 return state.el.hasClass('is-playing');
-            }).done(done);
+            }).always(done);
         });
 
         it('destroy itself on "play" event', function() {


### PR DESCRIPTION
## Summary

Split out of #262 per [review feedback](https://github.com/openedx/xblocks-core/pull/262#pullrequestreview-4663353846) — these flaky-test fixes are unrelated to the Problem Block JS modernization (issue #438) and belong in their own PR.

- `video_caption_spec.js` — fix flaky VideoCaption Flash mode transcript test
- `html5_video_spec.js`, `video_bumper_spec.js`, `video_poster_spec.js` — fix flaky `beforeEach` timeouts by switching async handling from `.done` to `.always`, avoiding a `mostRecent()` race with analytics calls

## Test plan

- [ ] `npm test` — video Karma specs (`html5_video_spec.js`, `video_bumper_spec.js`, `video_caption_spec.js`, `video_poster_spec.js`) pass consistently across repeated runs