### PR TITLE
fix: update pypi-publish action to use release/v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@7f25271a4aa483500f742f9492b2ab5648d61011 # v1.12.4
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_UPLOAD_TOKEN }}


### PR DESCRIPTION
## Description:

This PR is the fix for the failing Publish to PyPI workflow 
Ref:https://github.com/openedx/xblocks-core/actions/runs/29327012856/job/87066591905

What we fix:

  The original PR used a pinned commit SHA for v1.12.4. By the time the PR was merged and the release ran, pypa had already deleted that Docker image from ghcr.io (they released v1.13.0 and v1.14.0 since then and cleaned up old images). 

release/v1 is a protected branch maintained by pypa specifically as the stable floating reference. They guarantee that its Docker image always stays alive and up to date. Verified from the API — it's protected and currently points to v1.14.0.

The sample-plugin repository, which serves as the reference repository for the [modernization tooling](https://github.com/openedx/public-engineering/issues/506), also uses the same approach.
Ref: https://github.com/openedx/sample-plugin/blob/00aa9441d0219e8773042da7c0a50508a2b30880/.github/workflows/release.yml#L107