### PR TITLE
fix: pin pypa/gh-action-pypi-publish to a commit SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           user: __token__
           password: ${{ secrets.PYPI_UPLOAD_TOKEN }}


### PR DESCRIPTION
## Summary

Pin `pypa/gh-action-pypi-publish` to a commit SHA (was `@release/v1`, a floating branch ref).

## Why

Your release run on 2026-07-14 failed with `docker: manifest unknown`: https://github.com/openedx/xblocks-core/actions/runs/29327012856/job/87066591905

`@release/v1` is a floating branch, not a version tag -- it resolved to a commit whose Docker image wasn't yet published on ghcr.io at the moment this workflow ran (a race between the branch moving and the image being built). The next release run happened to succeed once the image caught up, but the underlying race is still there and will fail unpredictably again on a future release.

This traces back to `openedx/sample-plugin`'s `release.yml` (the reference implementation for the org-wide Python tooling modernization effort), which has the same unpinned ref -- filed a matching fix there: openedx/sample-plugin#54.

## Test plan

- YAML is unchanged apart from the one `uses:` line; no functional change to the workflow's logic.
- SHA `cef221092ed1bacb1cc03d23a2d87d1d172e277b` is the current tip of `pypa/gh-action-pypi-publish`'s `release/v1` branch (v1.14.0) as of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
