### PR TITLE
fix(problem): use CSS logical properties for RTL layout support

### DIFF
--- a/xblocks_contrib/problem/assets/static/css/ProblemBlockDisplay.css
+++ b/xblocks_contrib/problem/assets/static/css/ProblemBlockDisplay.css
@@ -322,7 +322,7 @@
 .xmodule_display.xmodule_ProblemBlock div.problem .choicegroup input[type="checkbox"],
 .xmodule_display.xmodule_ProblemBlock div.problem .choicetextgroup input[type="checkbox"] {
     margin: calc((var(--baseline, 20px) / 4));
-    margin-right: calc((var(--baseline, 20px) / 2));
+    margin-inline-end: calc((var(--baseline, 20px) / 2));
 }
 
 .xmodule_display.xmodule_ProblemBlock div.problem .choicegroup input:focus + label,
@@ -885,7 +885,7 @@
 
 .xmodule_display.xmodule_ProblemBlock div.problem .choicegroup label {
     padding: calc((var(--baseline, 20px) / 2));
-    padding-left: calc((var(--baseline, 20px) * 2.3));
+    padding-inline-start: calc((var(--baseline, 20px) * 2.3));
     position: relative;
     font-size: var(--base-font-size, 18px);
     line-height: normal;
@@ -894,7 +894,7 @@
 
 .xmodule_display.xmodule_ProblemBlock div.problem .choicegroup input[type="radio"],
 .xmodule_display.xmodule_ProblemBlock div.problem .choicegroup input[type="checkbox"] {
-    left: 0.5625em;
+    inset-inline-start: 0.5625em;
     position: absolute;
     top: 0.43em;
     width: calc(var(--baseline, 20px) * 1.1);


### PR DESCRIPTION
# Description

This PR fixes alignment and layout issues in Right-to-Left (RTL) languages for the `ProblemBlock` (`xblocks_contrib.problem`).

Previously, `ProblemBlockDisplay.css` used physical directional properties (`margin-right`, `padding-left`, `left`) that forced checkboxes, radio buttons, and labels to remain LTR-aligned even when rendering the platform in RTL languages (such as Arabic). 

These physical properties have been replaced with **CSS logical properties**, allowing the browser to dynamically mirror alignments depending on the text direction (`dir="ltr"` or `dir="rtl"`).

## Changes Made

* **`xblocks_contrib/problem/assets/static/css/ProblemBlockDisplay.css`**:
  * Replaced `margin-right` with `margin-inline-end` for choicetextgroup inputs.
  * Replaced `padding-left` with `padding-inline-start` for choicegroup labels.
  * Replaced `left` with `inset-inline-start` for radio buttons and checkboxes.

## How to Test

1. Checkout this branch

2. Run `npm install` in the root directory of `xblocks-core`:
   `npm install`

3. Build the assets:
   `npm run build`

4. Go to a course page containing a problem block and verify the layout:
   * **English (LTR):** Verify that input choices, radio buttons, and labels retain their normal left-to-right alignment.
   * **Arabic (RTL):** Verify that input choices, radio buttons, and margins correctly mirror to the right side.

## Before
#### EN
<img width="1673" height="988" alt="image" src="https://github.com/user-attachments/assets/3026f50a-39ae-405d-8872-b1ab9f2e9b58" />

#### AR
<img width="1673" height="988" alt="image" src="https://github.com/user-attachments/assets/8f595f2d-ed30-41c6-8132-e9d5b93cead4" />


## After
#### EN
<img width="1673" height="988" alt="image" src="https://github.com/user-attachments/assets/2b039fc9-c8fa-43d0-bdc9-05ce4a908344" />


#### AR
<img width="1673" height="988" alt="image" src="https://github.com/user-attachments/assets/23ddec09-65e6-47f2-bf49-3cdf87fc5fb8" />


## NOTE
The platform contains a bug that doesn't allow to  align correctly to see the full version please use this branch https://github.com/eduNEXT/edx-platform/tree/and/fix-problem-rtl
<img width="1673" height="988" alt="image" src="https://github.com/user-attachments/assets/1c5bf6ef-a5b8-4d65-b400-e2f4150578fc" />
