### PR TITLE
fix: keep the edx_video_id for libraries

### DIFF
--- a/xblocks_contrib/video/tests/test_video.py
+++ b/xblocks_contrib/video/tests/test_video.py
@@ -311,6 +311,38 @@ class VideoBlockImportTestCase(TestCase):
             },
         )
 
+    @patch("xblocks_contrib.video.video.VideoBlock.import_video_info_into_val")
+    def test_parse_xml_new_runtime_keeps_edx_video_id(self, mock_import_into_val):
+        """
+        In the new (content libraries v2) runtime, ``parse_xml_new_runtime`` must
+        preserve ``edx_video_id`` from the OLX and must NOT import ``<video_asset>``
+        data into VAL (there is no course to associate the video with).
+
+        Regression test: nulling ``edx_video_id`` here caused library videos to
+        render "No playable video source" and the ID to vanish from the editor
+        after save. Videos already present in VAL must keep resolving.
+        """
+        runtime = DummyRuntime(load_error_blocks=True)
+        edx_video_id = "8e92a901-88cb-4e0c-9999-000000000000"
+        xml_data = f"""
+            <video edx_video_id="{edx_video_id}" display_name="Test Video">
+                <video_asset client_video_id="4K UHD Video">
+                    <encoded_video profile="hls" url="https://example.com/v.m3u8"/>
+                    <encoded_video profile="desktop_mp4" url="https://example.com/v.mp4"/>
+                </video_asset>
+            </video>
+        """
+        node = etree.fromstring(xml_data)
+        keys = ScopeIds("user", "video", "def_id", "usage_id")
+
+        block = VideoBlock.parse_xml_new_runtime(node, runtime, keys)
+
+        # The fix: edx_video_id survives so videos already in VAL keep working.
+        assert block.edx_video_id == edx_video_id
+        # And, unlike the course path (.parse_xml), the new runtime deliberately
+        # does not push <video_asset> encodings into VAL.
+        mock_import_into_val.assert_not_called()
+
     @XBlockAside.register_temp_plugin(AsideTestType, "test_aside")
     @patch("xblocks_contrib.video.video.VideoBlock.load_file")
     @patch("xblocks_contrib.video.video.is_pointer_tag")

--- a/xblocks_contrib/video/video.py
+++ b/xblocks_contrib/video/video.py
@@ -606,8 +606,11 @@ class VideoBlock(
             if key not in cls.fields:  # pylint: disable=unsupported-membership-test
                 continue  # parse_video_xml returns some old non-fields like 'source'
             setattr(video_block, key, cls.fields[key].from_json(val))
-        # Don't use VAL in the new runtime:
-        video_block.edx_video_id = None
+        # Note: unlike .parse_xml(), we do not import <video_asset> data into VAL here
+        # (there is no course to associate the video with), but we deliberately keep
+        # edx_video_id so that videos already present in VAL on this instance keep
+        # working in content libraries. Nulling it out caused "No playable video
+        # source" and the ID vanishing from the editor after save.
         return video_block
 
     @classmethod


### PR DESCRIPTION
Recreation of #282, which was blocked by a failing CLA check on the original author's commits. This PR re-applies the same change with commits authored under my (CLA-signed) account so the check can pass. All credit for the fix and tests belongs to @marslanabdulrauf.

## Related Ticket
https://github.com/mitodl/hq/issues/12414 (MIT Internal)

## Steps to reproduce the Issue:
1. Get video id from course videos
2. Create or go to any Library, add video component. Go to the video component, put the video id in and save (optionally publish)
3. Click edit again and the "Video ID" is missing now.
4. Strangely though you can see it in the "Advanced Details"
5. And in the preview we get "No playable video source"

## Possible root cause:
For new runtime `edxval edx_video_id` is being set to None which causes no sources to be loaded, which leads to this "No playable video sources found." error.

## Description
This pull request updates the handling of the `edx_video_id` field in the `parse_xml_new_runtime` method to improve video compatibility in content libraries. Instead of setting `edx_video_id` to `None`, the code now retains its value, ensuring that videos already present in the Video Asset Library (VAL) continue to work as expected.

- Video compatibility fix:
  * `video.py`: Updated `parse_xml_new_runtime` to retain the `edx_video_id` field, preventing issues where videos become unplayable or lose their ID in the editor after saving.

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets